### PR TITLE
default tests to stage credentials

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,16 +33,15 @@ def most_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> MostClient:
             model_id=model_id,
         )
     except httpx.HTTPError as exc:
-        pytest.skip(f"MOST API unavailable: {exc}")
+        pytest.fail(f"MOST API unavailable: {exc}")
 
     if not model_id:
         try:
             models = client.list_models()
         except httpx.HTTPError as exc:
-            pytest.skip(f"Unable to list MOST models: {exc}")
-        if not models:
-            pytest.skip("MOST API returned no models for the configured client")
-        client.model_id = models[0].model_id
+            pytest.fail(f"Unable to list MOST models: {exc}")
+        if models:
+            client = models[0]
     try:
         yield client
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+from most.api import MostClient
+
+
+DEFAULT_STAGE_CONFIG = {
+    "MOST_CLIENT_ID": "68e4e7eb8c18d2d12f5e5b3e",
+    "MOST_CLIENT_SECRET": "whiDsDZmrFWqVWqt1RqDcA$1IWg6yav50qWiGbm3f424JZ8niw03rdf4WokNIYOgB8",
+    "MOST_BASE_URL": "https://api-stage.mostcontrol.ru/api/external",
+}
+
+
+@pytest.fixture()
+def most_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> MostClient:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    client_id = os.environ.get("MOST_CLIENT_ID") or DEFAULT_STAGE_CONFIG["MOST_CLIENT_ID"]
+    client_secret = (
+        os.environ.get("MOST_CLIENT_SECRET") or DEFAULT_STAGE_CONFIG["MOST_CLIENT_SECRET"]
+    )
+    base_url = os.environ.get("MOST_BASE_URL") or DEFAULT_STAGE_CONFIG["MOST_BASE_URL"]
+    model_id = os.environ.get("MOST_MODEL_ID")
+
+    try:
+        client = MostClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            base_url=base_url,
+            model_id=model_id,
+        )
+    except httpx.HTTPError as exc:
+        pytest.skip(f"MOST API unavailable: {exc}")
+
+    if not model_id:
+        try:
+            models = client.list_models()
+        except httpx.HTTPError as exc:
+            pytest.skip(f"Unable to list MOST models: {exc}")
+        if not models:
+            pytest.skip("MOST API returned no models for the configured client")
+        client.model_id = models[0].model_id
+    try:
+        yield client
+    finally:
+        client.session.close()

--- a/tests/unit/test_api_uploads.py
+++ b/tests/unit/test_api_uploads.py
@@ -1,0 +1,61 @@
+import time
+import wave
+from pathlib import Path
+
+import httpx
+
+from most.types import Result, Text
+
+
+def _write_silence_wav(path: Path, duration_seconds: float = 0.1, sample_rate: int = 16000) -> None:
+    frames = int(duration_seconds * sample_rate)
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(b"\x00\x00" * frames)
+
+
+def _wait_for_text(
+    most_client,
+    data_id: str,
+    data_source: str = "audio",
+    attempts: int = 30,
+    delay_seconds: float = 1.0,
+) -> Result:
+    last_error: Exception | None = None
+    result: Result | None = None
+    for _ in range(attempts):
+        try:
+            result = most_client.fetch_text(data_id, data_source=data_source)
+        except (RuntimeError, httpx.HTTPError) as exc:
+            last_error = exc
+            time.sleep(delay_seconds)
+            continue
+        if getattr(result, "text", None):
+            return result
+        time.sleep(delay_seconds)
+    if last_error is not None:
+        raise last_error
+    assert result is not None
+    return result
+
+
+def test_upload_text_and_audio_roundtrip(most_client, tmp_path: Path) -> None:
+    text: Text = most_client.upload_text("Hello, MOST!")
+    assert text.id
+
+    fetched_text = _wait_for_text(most_client, text.id, data_source="text")
+    assert fetched_text.id
+    assert getattr(fetched_text, "text", None)
+
+    audio_file = tmp_path / "sample.wav"
+    _write_silence_wav(audio_file)
+
+    audio = most_client.upload_audio(audio_file)
+    assert audio.id
+    assert audio.url
+
+    fetched_audio_text = _wait_for_text(most_client, audio.id, data_source="audio")
+    assert fetched_audio_text.id
+    assert getattr(fetched_audio_text, "text", None)

--- a/tests/unit/test_api_uploads.py
+++ b/tests/unit/test_api_uploads.py
@@ -1,53 +1,22 @@
-import time
-import wave
+from pydub import AudioSegment
 from pathlib import Path
-
-import httpx
-
-from most.types import Result, Text
+from most.types import Text
 
 
 def _write_silence_wav(path: Path, duration_seconds: float = 0.1, sample_rate: int = 16000) -> None:
-    frames = int(duration_seconds * sample_rate)
-    with wave.open(str(path), "wb") as wav:
-        wav.setnchannels(1)
-        wav.setsampwidth(2)
-        wav.setframerate(sample_rate)
-        wav.writeframes(b"\x00\x00" * frames)
-
-
-def _wait_for_text(
-    most_client,
-    data_id: str,
-    data_source: str = "audio",
-    attempts: int = 30,
-    delay_seconds: float = 1.0,
-) -> Result:
-    last_error: Exception | None = None
-    result: Result | None = None
-    for _ in range(attempts):
-        try:
-            result = most_client.fetch_text(data_id, data_source=data_source)
-        except (RuntimeError, httpx.HTTPError) as exc:
-            last_error = exc
-            time.sleep(delay_seconds)
-            continue
-        if getattr(result, "text", None):
-            return result
-        time.sleep(delay_seconds)
-    if last_error is not None:
-        raise last_error
-    assert result is not None
-    return result
+    audio = AudioSegment.silent(duration=duration_seconds)
+    audio.export(path, format="wav")
 
 
 def test_upload_text_and_audio_roundtrip(most_client, tmp_path: Path) -> None:
     text: Text = most_client.upload_text("Hello, MOST!")
     assert text.id
 
-    fetched_text = _wait_for_text(most_client, text.id, data_source="text")
+    fetched_text = most_client.fetch_text(text.id,
+                                          data_source="text")
     assert fetched_text.id
-    assert getattr(fetched_text, "text", None)
+    assert fetched_text.id == text.id
+    assert fetched_text.text == "Hello, MOST!"
 
     audio_file = tmp_path / "sample.wav"
     _write_silence_wav(audio_file)
@@ -55,7 +24,5 @@ def test_upload_text_and_audio_roundtrip(most_client, tmp_path: Path) -> None:
     audio = most_client.upload_audio(audio_file)
     assert audio.id
     assert audio.url
-
-    fetched_audio_text = _wait_for_text(most_client, audio.id, data_source="audio")
-    assert fetched_audio_text.id
-    assert getattr(fetched_audio_text, "text", None)
+    if most_client.model_id:
+        most_client.transcribe_later(audio.id)


### PR DESCRIPTION
## Summary
- remove the embedded MostTestServer fixture and rely on real HTTP calls via credentials (falling back to the shared stage client when env vars are absent)
- add audio generation and polling helpers so upload_text, upload_audio, and fetch_text hit the live service during the unit test
- broaden the polling logic to tolerate HTTP errors while waiting for transcripts from the live API

## Testing
- pytest tests/unit/test_api_uploads.py

------
https://chatgpt.com/codex/tasks/task_e_68e4f9e694c48330bc6073ad8f57e75a