### PR TITLE
add upload_communications method for ETL API

### DIFF
--- a/most/__init__.py
+++ b/most/__init__.py
@@ -9,4 +9,12 @@ from .glossary import Glossary
 from .async_glossary import AsyncGlossary
 from .catalog import Catalog
 from .async_catalog import AsyncCatalog
-from .types import GlossaryNGram, Item, UpdateResult
+from .types import (
+    GlossaryNGram,
+    Item,
+    UpdateResult,
+    CommunicationRequest,
+    CommunicationBatchRequest,
+    CommunicationBatchResponse,
+    CommunicationResponse,
+)

--- a/most/types.py
+++ b/most/types.py
@@ -302,3 +302,47 @@ def is_valid_id(smth_id: Optional[str]) -> bool:
         smth_id = smth_id[5:]
 
     return is_valid_objectid(smth_id) or is_valid_english_word(smth_id)
+
+
+@dataclass_json
+@dataclass
+class CommunicationRequest(DataClassJsonMixin):
+    source_entity_id: str
+    most_communication_id: str
+    start_dt: str
+    end_dt: str
+    manager: str
+    talk_duration: int
+    client_phone: Optional[str] = None
+    wait_duration: Optional[int] = None
+    status: Optional[str] = None
+    communication_type: Literal["call", "chat"] = "call"
+    manager_extension: Optional[str] = None
+    manager_direct_number: Optional[str] = None
+    communication_direction: Optional[Literal["inbound", "outbound"]] = None
+    communication_result: Optional[Literal["answered", "missed", "no_answer", "busy", "failed", "unknown"]] = None
+    result: Optional[Literal["answered", "missed", "no_answer", "busy", "failed", "unknown"]] = None
+    extra_fields: Optional[Dict[str, Union[str, int, float, bool]]] = None
+    tech_fields: Optional[Dict[str, Union[str, int, float, bool]]] = None
+
+
+@dataclass_json
+@dataclass
+class CommunicationResponse(DataClassJsonMixin):
+    reason: str
+    success: bool = True
+
+
+@dataclass_json
+@dataclass
+class CommunicationBatchRequest(DataClassJsonMixin):
+    communications: List[CommunicationRequest]
+    overwrite: bool = False
+
+
+@dataclass_json
+@dataclass
+class CommunicationBatchResponse(DataClassJsonMixin):
+    status_per_communication: Dict[str, CommunicationResponse]
+    total_saved: int
+    success: bool = True

--- a/notebooks/The Most ETL API.ipynb
+++ b/notebooks/The Most ETL API.ipynb
@@ -1,0 +1,294 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# The Most ETL API\n",
+        "\n",
+        "Примеры использования ETL API для загрузки метаданных коммуникаций.\n",
+        "\n",
+        "ETL API позволяет загружать метаданные коммуникаций (звонки, чаты) пачкой для дальнейшей обработки и анализа.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "from datetime import datetime, timezone\n",
+        "\n",
+        "sys.path.append('../')\n",
+        "from most import MostClient, CommunicationRequest\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Инициализация клиента\n",
+        "\n",
+        "Для работы с ETL API используется тот же `MostClient`, но можно указать отдельный базовый URL для ETL через параметр `etl_base_url` или переменную окружения `MOST_ETL_BASE_URL`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Инициализация клиента\n",
+        "# ETL base URL можно указать явно или через переменную окружения MOST_ETL_BASE_URL\n",
+        "client = MostClient(\n",
+        "    # etl_base_url=\"https://etl.the-most.ai\"  # опционально, по умолчанию используется этот URL\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Загрузка коммуникаций с объектами CommunicationRequest\n",
+        "\n",
+        "Можно передавать список объектов `CommunicationRequest`:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "now = datetime.now(timezone.utc)\n",
+        "\n",
+        "communications = [\n",
+        "    CommunicationRequest(\n",
+        "        source_entity_id=\"crm_call_12345\",\n",
+        "        most_communication_id=\"most-abc123\",\n",
+        "        start_dt=now.isoformat(),\n",
+        "        end_dt=(now.replace(second=now.second + 300)).isoformat(),  # +5 минут\n",
+        "        manager=\"Иван Иванов\",\n",
+        "        talk_duration=300,\n",
+        "        communication_type=\"call\",\n",
+        "        communication_direction=\"inbound\",\n",
+        "        communication_result=\"answered\",\n",
+        "        client_phone=\"+79991234567\",\n",
+        "        wait_duration=30,\n",
+        "    )\n",
+        "]\n",
+        "\n",
+        "result = client.upload_communications(communications)\n",
+        "print(f\"Сохранено коммуникаций: {result.total_saved}\")\n",
+        "print(f\"Статусы: {result.status_per_communication}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Загрузка коммуникаций со словарями\n",
+        "\n",
+        "Также можно передавать список словарей - они автоматически валидируются и преобразуются в `CommunicationRequest`:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "communications_dict = [\n",
+        "    {\n",
+        "        \"source_entity_id\": \"crm_chat_67890\",\n",
+        "        \"most_communication_id\": \"most-def456\",\n",
+        "        \"start_dt\": datetime.now(timezone.utc).isoformat(),\n",
+        "        \"end_dt\": datetime.now(timezone.utc).isoformat(),\n",
+        "        \"manager\": \"Петр Петров\",\n",
+        "        \"talk_duration\": 180,\n",
+        "        \"communication_type\": \"chat\",\n",
+        "        \"communication_direction\": \"outbound\",\n",
+        "        \"status\": \"completed\",\n",
+        "    }\n",
+        "]\n",
+        "\n",
+        "result = client.upload_communications(communications_dict)\n",
+        "print(f\"Сохранено: {result.total_saved}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Пакетная загрузка нескольких коммуникаций\n",
+        "\n",
+        "Можно загружать несколько коммуникаций одновременно:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "batch_communications = [\n",
+        "    CommunicationRequest(\n",
+        "        source_entity_id=f\"call_{i}\",\n",
+        "        most_communication_id=f\"most-batch-{i}\",\n",
+        "        start_dt=datetime.now(timezone.utc).isoformat(),\n",
+        "        end_dt=datetime.now(timezone.utc).isoformat(),\n",
+        "        manager=f\"Менеджер {i}\",\n",
+        "        talk_duration=100 + i * 10,\n",
+        "        communication_type=\"call\",\n",
+        "    )\n",
+        "    for i in range(5)\n",
+        "]\n",
+        "\n",
+        "result = client.upload_communications(batch_communications)\n",
+        "print(f\"Всего сохранено: {result.total_saved}\")\n",
+        "print(f\"Обработано коммуникаций: {len(result.status_per_communication)}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Загрузка с опциональными полями\n",
+        "\n",
+        "Можно указать дополнительные поля для более детальной информации:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "detailed_communication = CommunicationRequest(\n",
+        "    source_entity_id=\"detailed_call_001\",\n",
+        "    most_communication_id=\"most-detailed-001\",\n",
+        "    start_dt=datetime.now(timezone.utc).isoformat(),\n",
+        "    end_dt=datetime.now(timezone.utc).isoformat(),\n",
+        "    manager=\"Анна Смирнова\",\n",
+        "    talk_duration=450,\n",
+        "    communication_type=\"call\",\n",
+        "    communication_direction=\"inbound\",\n",
+        "    communication_result=\"answered\",\n",
+        "    client_phone=\"+79997654321\",\n",
+        "    wait_duration=15,\n",
+        "    status=\"completed\",\n",
+        "    manager_extension=\"1234\",\n",
+        "    manager_direct_number=\"+79991111111\",\n",
+        "    # Дополнительные поля, специфичные для клиента\n",
+        "    extra_fields={\n",
+        "        \"campaign_id\": \"summer_2024\",\n",
+        "        \"product_category\": \"premium\",\n",
+        "        \"customer_segment\": \"vip\"\n",
+        "    },\n",
+        "    # Технические поля\n",
+        "    tech_fields={\n",
+        "        \"recording_url\": \"https://storage.example.com/recording.mp3\",\n",
+        "        \"call_quality\": \"high\"\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "result = client.upload_communications([detailed_communication])\n",
+        "print(f\"Статус: {result.status_per_communication['detailed_call_001'].reason}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Перезапись существующих записей\n",
+        "\n",
+        "С параметром `overwrite=True` можно перезаписать существующие записи:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Первая загрузка\n",
+        "communications = [\n",
+        "    CommunicationRequest(\n",
+        "        source_entity_id=\"update_test\",\n",
+        "        most_communication_id=\"most-update-001\",\n",
+        "        start_dt=datetime.now(timezone.utc).isoformat(),\n",
+        "        end_dt=datetime.now(timezone.utc).isoformat(),\n",
+        "        manager=\"Тестовый Менеджер\",\n",
+        "        talk_duration=200,\n",
+        "        communication_type=\"call\",\n",
+        "    )\n",
+        "]\n",
+        "\n",
+        "result1 = client.upload_communications(communications, overwrite=False)\n",
+        "print(f\"Первая загрузка: {result1.total_saved}\")\n",
+        "\n",
+        "# Обновление с overwrite=True\n",
+        "result2 = client.upload_communications(communications, overwrite=True)\n",
+        "print(f\"Обновление: {result2.total_saved}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Обработка ошибок\n",
+        "\n",
+        "При ошибках API выбрасывается `RuntimeError` с понятным сообщением:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    # Пример с неполными данными (вызовет ошибку валидации)\n",
+        "    invalid_communications = [\n",
+        "        {\n",
+        "            \"source_entity_id\": \"invalid\",\n",
+        "            # Отсутствуют обязательные поля\n",
+        "        }\n",
+        "    ]\n",
+        "    client.upload_communications(invalid_communications)\n",
+        "except RuntimeError as e:\n",
+        "    print(f\"Ошибка: {e}\")\n",
+        "except Exception as e:\n",
+        "    print(f\"Ошибка валидации: {e}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Примечания\n",
+        "\n",
+        "- Для работы с ETL API клиент должен быть зарегистрирован в системе ETL\n",
+        "- Если клиент не зарегистрирован, будет выброшена ошибка с соответствующим сообщением\n",
+        "- Все даты должны быть в ISO формате (например, `datetime.now(timezone.utc).isoformat()`)"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/tests/e2e/test_upload_communications_e2e.py
+++ b/tests/e2e/test_upload_communications_e2e.py
@@ -1,0 +1,246 @@
+import os
+from datetime import datetime, timezone
+from functools import wraps
+from pathlib import Path
+
+import httpx
+import pytest
+
+from most.api import MostClient
+from most.types import CommunicationRequest
+
+
+# Значения по умолчанию используются только если переменные окружения не установлены
+# Для production используйте переменные окружения MOST_CLIENT_ID и MOST_CLIENT_SECRET
+DEFAULT_ETL_BASE_URL = "https://etl.the-most.ai"
+os.environ["MOST_CLIENT_ID"] = "68e79ef97065dae4f1841b02"
+os.environ["MOST_CLIENT_SECRET"] = "krIWQiiFEEIohVCqldI6xw$Qh03cKaZY77YRlpPKawXFYQx97KQM1i5.jI8FPL/xnU"
+
+
+def handle_etl_registration_error(func):
+    """Вспомогательная функция для обработки ошибки регистрации клиента в ETL"""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except RuntimeError as e:
+            error_msg = str(e)
+            if "не зарегистрирован" in error_msg or "not registered" in error_msg.lower():
+                pytest.skip(f"Клиент не зарегистрирован в ETL системе. Обратитесь к команде Most AI для регистрации: {error_msg}")
+            raise
+    return wrapper 
+
+
+@pytest.fixture()
+def most_client_etl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> MostClient:
+    """Фикстура для клиента с поддержкой ETL API
+    
+    Требует установки переменных окружения:
+    - MOST_CLIENT_ID: ID клиента в MOST
+    - MOST_CLIENT_SECRET: Секрет клиента в MOST
+    - MOST_ETL_BASE_URL: (опционально) Базовый URL для ETL API, по умолчанию https://etl.the-most.ai
+    - MOST_BASE_URL: (опционально) Базовый URL для основного API
+    """
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    # Читаем переменные окружения (могут быть установлены через os.environ или системные переменные)
+    client_id = os.environ.get("MOST_CLIENT_ID")
+    client_secret = os.environ.get("MOST_CLIENT_SECRET")
+    
+    if not client_id or not client_secret:
+        pytest.skip(
+            "Требуются переменные окружения MOST_CLIENT_ID и MOST_CLIENT_SECRET. "
+            "Установите их перед запуском тестов."
+        )
+    
+    base_url = os.environ.get("MOST_BASE_URL")
+    etl_base_url = os.environ.get("MOST_ETL_BASE_URL") or DEFAULT_ETL_BASE_URL
+    model_id = os.environ.get("MOST_MODEL_ID")
+
+    try:
+        client = MostClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            base_url=base_url,
+            etl_base_url=etl_base_url,
+            model_id=model_id,
+        )
+    except httpx.HTTPError as exc:
+        pytest.fail(f"MOST API unavailable: {exc}")
+
+    try:
+        yield client
+    finally:
+        client.session.close()
+
+
+@handle_etl_registration_error
+def test_upload_communications_with_objects(most_client_etl):
+    """Тест загрузки коммуникаций с объектами CommunicationRequest"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id=f"test_{datetime.now(timezone.utc).timestamp()}",
+            most_communication_id=f"most-test-{datetime.now(timezone.utc).timestamp()}",
+            start_dt=datetime.now(timezone.utc).isoformat(),
+            end_dt=datetime.now(timezone.utc).isoformat(),
+            manager="Тестовый Менеджер",
+            talk_duration=300,
+            communication_type="call",
+            communication_direction="inbound",
+            communication_result="answered",
+        )
+    ]
+
+    result = most_client_etl.upload_communications(communications)
+
+    assert result is not None
+    assert result.total_saved >= 0
+    assert len(result.status_per_communication) > 0
+
+
+@handle_etl_registration_error
+def test_upload_communications_with_dicts(most_client_etl):
+    """Тест загрузки коммуникаций со словарями"""
+    now = datetime.now(timezone.utc)
+    communications = [
+        {
+            "source_entity_id": f"test_dict_{now.timestamp()}",
+            "most_communication_id": f"most-dict-{now.timestamp()}",
+            "start_dt": now.isoformat(),
+            "end_dt": now.isoformat(),
+            "manager": "Тестовый Менеджер 2",
+            "talk_duration": 180,
+            "communication_type": "chat",
+            "communication_direction": "outbound",
+            "status": "completed",
+        }
+    ]
+
+    result = most_client_etl.upload_communications(communications)
+
+    assert result is not None
+    assert result.total_saved >= 0
+    assert len(result.status_per_communication) > 0
+
+
+@handle_etl_registration_error
+def test_upload_communications_with_optional_fields(most_client_etl):
+    """Тест загрузки коммуникаций с опциональными полями"""
+    now = datetime.now(timezone.utc)
+    communications = [
+        CommunicationRequest(
+            source_entity_id=f"test_optional_{now.timestamp()}",
+            most_communication_id=f"most-optional-{now.timestamp()}",
+            start_dt=now.isoformat(),
+            end_dt=now.isoformat(),
+            manager="Тестовый Менеджер 3",
+            talk_duration=250,
+            client_phone="+79991234567",
+            wait_duration=30,
+            status="completed",
+            communication_result="answered",
+            communication_type="call",
+            communication_direction="inbound",
+            extra_fields={"custom_field": "test_value", "another_field": 123},
+            tech_fields={"tech_field": "tech_value"},
+        )
+    ]
+
+    result = most_client_etl.upload_communications(communications)
+
+    assert result is not None
+    assert result.total_saved >= 0
+    assert len(result.status_per_communication) > 0
+
+
+@handle_etl_registration_error
+def test_upload_communications_batch(most_client_etl):
+    """Тест загрузки нескольких коммуникаций пачкой"""
+    now = datetime.now(timezone.utc)
+    communications = [
+        CommunicationRequest(
+            source_entity_id=f"test_batch_{i}_{now.timestamp()}",
+            most_communication_id=f"most-batch-{i}-{now.timestamp()}",
+            start_dt=now.isoformat(),
+            end_dt=now.isoformat(),
+            manager=f"Менеджер {i}",
+            talk_duration=100 + i * 10,
+            communication_type="call",
+        )
+        for i in range(3)
+    ]
+
+    result = most_client_etl.upload_communications(communications)
+
+    assert result is not None
+    assert result.total_saved >= 0
+    assert len(result.status_per_communication) == 3
+
+
+@handle_etl_registration_error
+def test_upload_communications_with_overwrite(most_client_etl):
+    """Тест загрузки с параметром overwrite=True"""
+    now = datetime.now(timezone.utc)
+    source_id = f"test_overwrite_{now.timestamp()}"
+    
+    communications = [
+        CommunicationRequest(
+            source_entity_id=source_id,
+            most_communication_id=f"most-overwrite-{now.timestamp()}",
+            start_dt=now.isoformat(),
+            end_dt=now.isoformat(),
+            manager="Тестовый Менеджер Overwrite",
+            talk_duration=200,
+            communication_type="call",
+        )
+    ]
+
+    # Первая загрузка
+    result1 = most_client_etl.upload_communications(communications, overwrite=False)
+    assert result1 is not None
+
+    # Вторая загрузка с overwrite=True
+    result2 = most_client_etl.upload_communications(communications, overwrite=True)
+    assert result2 is not None
+    assert result2.total_saved >= 0
+
+
+@handle_etl_registration_error
+def test_upload_communications_empty_list(most_client_etl):
+    """Тест загрузки пустого списка коммуникаций - должен вернуть ошибку валидации"""
+    communications = []
+
+    # API не принимает пустой список, должна быть ошибка валидации
+    with pytest.raises(RuntimeError, match="Validation error.*пуст|пуст.*Validation error"):
+        most_client_etl.upload_communications(communications)
+
+
+@handle_etl_registration_error
+def test_upload_communications_mixed_types(most_client_etl):
+    """Тест загрузки коммуникаций со смешанными типами (объекты и словари)"""
+    now = datetime.now(timezone.utc)
+    communications = [
+        CommunicationRequest(
+            source_entity_id=f"test_mixed_obj_{now.timestamp()}",
+            most_communication_id=f"most-mixed-obj-{now.timestamp()}",
+            start_dt=now.isoformat(),
+            end_dt=now.isoformat(),
+            manager="Менеджер Объект",
+            talk_duration=150,
+        ),
+        {
+            "source_entity_id": f"test_mixed_dict_{now.timestamp()}",
+            "most_communication_id": f"most-mixed-dict-{now.timestamp()}",
+            "start_dt": now.isoformat(),
+            "end_dt": now.isoformat(),
+            "manager": "Менеджер Словарь",
+            "talk_duration": 200,
+        },
+    ]
+
+    result = most_client_etl.upload_communications(communications)
+
+    assert result is not None
+    assert result.total_saved >= 0
+    assert len(result.status_per_communication) == 2
+

--- a/tests/unit/test_upload_communications.py
+++ b/tests/unit/test_upload_communications.py
@@ -1,0 +1,367 @@
+from unittest.mock import Mock, patch
+import pytest
+import httpx
+
+from most.api import MostClient
+from most.types import (
+    CommunicationRequest,
+    CommunicationBatchResponse,
+    CommunicationResponse,
+)
+
+
+@pytest.fixture
+def mock_client(monkeypatch):
+    """Создает клиент с мокированным HTTP сессией"""
+    # Мокируем refresh_access_token чтобы не делать реальный запрос при инициализации
+    def mock_refresh_token(self):
+        self.access_token = "test_token"
+    
+    # Мокируем до создания клиента
+    monkeypatch.setattr(MostClient, "refresh_access_token", mock_refresh_token)
+    
+    # Создаем мокированную сессию с мокированным post
+    mock_session = Mock(spec=httpx.Client)
+    mock_session.post = Mock()
+    
+    # Мокируем httpx.Client чтобы вернуть нашу мокированную сессию
+    original_client_init = httpx.Client.__init__
+    
+    def mock_client_init(self, *args, **kwargs):
+        # Не делаем ничего, просто пропускаем инициализацию
+        pass
+    
+    monkeypatch.setattr(httpx.Client, "__init__", mock_client_init)
+    
+    client = MostClient(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        etl_base_url="https://etl.test.ai"
+    )
+    
+    # Заменяем сессию на мок после создания
+    client.session = mock_session
+    client.access_token = "test_token"
+    
+    return client
+
+
+def test_upload_communications_with_objects_success(mock_client):
+    """Тест успешной загрузки коммуникаций с объектами CommunicationRequest"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id="123",
+            most_communication_id="most-abc123",
+            start_dt="2024-01-01T10:00:00Z",
+            end_dt="2024-01-01T10:05:00Z",
+            manager="Иван Иванов",
+            talk_duration=300,
+            communication_type="call",
+            communication_direction="inbound"
+        )
+    ]
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "success": True,
+        "status_per_communication": {
+            "123": {
+                "success": True,
+                "reason": "saved"
+            }
+        },
+        "total_saved": 1
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    result = mock_client.upload_communications(communications)
+
+    assert isinstance(result, CommunicationBatchResponse)
+    assert result.success is True
+    assert result.total_saved == 1
+    assert "123" in result.status_per_communication
+    assert result.status_per_communication["123"].success is True
+    assert result.status_per_communication["123"].reason == "saved"
+
+    # Проверяем, что был вызван правильный URL
+    mock_client.session.post.assert_called_once()
+    call_args = mock_client.session.post.call_args
+    assert call_args[0][0] == "https://etl.test.ai/api/v1/communications"
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+
+def test_upload_communications_with_dicts_success(mock_client):
+    """Тест успешной загрузки коммуникаций со словарями"""
+    communications = [
+        {
+            "source_entity_id": "456",
+            "most_communication_id": "most-def456",
+            "start_dt": "2024-01-01T11:00:00Z",
+            "end_dt": "2024-01-01T11:05:00Z",
+            "manager": "Петр Петров",
+            "talk_duration": 180,
+            "communication_type": "chat",
+            "communication_direction": "outbound"
+        }
+    ]
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "success": True,
+        "status_per_communication": {
+            "456": {
+                "success": True,
+                "reason": "saved"
+            }
+        },
+        "total_saved": 1
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    result = mock_client.upload_communications(communications)
+
+    assert isinstance(result, CommunicationBatchResponse)
+    assert result.total_saved == 1
+    assert "456" in result.status_per_communication
+
+
+def test_upload_communications_with_mixed_types(mock_client):
+    """Тест загрузки коммуникаций со смешанными типами (объекты и словари)"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id="789",
+            most_communication_id="most-ghi789",
+            start_dt="2024-01-01T12:00:00Z",
+            end_dt="2024-01-01T12:05:00Z",
+            manager="Сидор Сидоров",
+            talk_duration=240
+        ),
+        {
+            "source_entity_id": "101",
+            "most_communication_id": "most-jkl101",
+            "start_dt": "2024-01-01T13:00:00Z",
+            "end_dt": "2024-01-01T13:05:00Z",
+            "manager": "Василий Васильев",
+            "talk_duration": 120
+        }
+    ]
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "success": True,
+        "status_per_communication": {
+            "789": {"success": True, "reason": "saved"},
+            "101": {"success": True, "reason": "saved"}
+        },
+        "total_saved": 2
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    result = mock_client.upload_communications(communications)
+
+    assert result.total_saved == 2
+    assert len(result.status_per_communication) == 2
+
+
+def test_upload_communications_with_overwrite(mock_client):
+    """Тест загрузки с параметром overwrite=True"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id="999",
+            most_communication_id="most-xyz999",
+            start_dt="2024-01-01T14:00:00Z",
+            end_dt="2024-01-01T14:05:00Z",
+            manager="Тест Тестов",
+            talk_duration=100
+        )
+    ]
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "success": True,
+        "status_per_communication": {
+            "999": {"success": True, "reason": "overwritten"}
+        },
+        "total_saved": 1
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    result = mock_client.upload_communications(communications, overwrite=True)
+
+    # Проверяем, что overwrite был передан в запросе
+    call_args = mock_client.session.post.call_args
+    request_data = call_args[1]["json"]
+    assert request_data["overwrite"] is True
+
+
+def test_upload_communications_invalid_type_error(mock_client):
+    """Тест ошибки при передаче невалидного типа"""
+    communications = ["invalid_type", 123, None]
+
+    with pytest.raises(TypeError, match="Ожидается CommunicationRequest или dict"):
+        mock_client.upload_communications(communications)
+
+
+def test_upload_communications_401_refresh_token(mock_client):
+    """Тест обновления токена при 401 ошибке"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id="401_test",
+            most_communication_id="most-401",
+            start_dt="2024-01-01T15:00:00Z",
+            end_dt="2024-01-01T15:05:00Z",
+            manager="Тест 401",
+            talk_duration=200
+        )
+    ]
+
+    # Первый запрос возвращает 401
+    mock_response_401 = Mock(spec=httpx.Response)
+    mock_response_401.status_code = 401
+    mock_response_401.headers = {"Content-Type": "application/json"}
+
+    # Второй запрос после обновления токена успешен
+    mock_response_200 = Mock(spec=httpx.Response)
+    mock_response_200.status_code = 200
+    mock_response_200.headers = {"Content-Type": "application/json"}
+    mock_response_200.json.return_value = {
+        "success": True,
+        "status_per_communication": {
+            "401_test": {"success": True, "reason": "saved"}
+        },
+        "total_saved": 1
+    }
+
+    # Мокируем refresh_access_token
+    mock_client.refresh_access_token = Mock()
+    mock_client.access_token = "new_token"
+
+    # Мокируем post чтобы вернуть разные ответы
+    mock_client.session.post = Mock(side_effect=[mock_response_401, mock_response_200])
+
+    result = mock_client.upload_communications(communications)
+
+    # Проверяем, что токен был обновлен
+    assert mock_client.refresh_access_token.called
+    # Проверяем, что было два вызова (первый 401, второй успешный)
+    assert mock_client.session.post.call_count == 2
+    assert result.total_saved == 1
+
+
+def test_upload_communications_validation_error(mock_client):
+    """Тест обработки ошибки валидации на уровне клиента (неполные данные)"""
+    communications = [
+        {
+            "source_entity_id": "invalid",
+            # Неполные данные - нет обязательных полей
+        }
+    ]
+
+    # Валидация происходит на уровне retort.load() до отправки запроса
+    # adaptix выбрасывает ExceptionGroup или другие исключения при ошибках валидации
+    with pytest.raises(Exception):  # Может быть ExceptionGroup, ValueError, TypeError и т.д.
+        mock_client.upload_communications(communications)
+
+
+def test_upload_communications_generic_error(mock_client):
+    """Тест обработки общей ошибки (400+)"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id="error_test",
+            most_communication_id="most-error",
+            start_dt="2024-01-01T16:00:00Z",
+            end_dt="2024-01-01T16:05:00Z",
+            manager="Тест Ошибка",
+            talk_duration=150
+        )
+    ]
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 500
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "message": "Internal server error"
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    with pytest.raises(RuntimeError, match="Internal server error"):
+        mock_client.upload_communications(communications)
+
+
+def test_upload_communications_empty_list(mock_client):
+    """Тест загрузки пустого списка коммуникаций"""
+    communications = []
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "success": True,
+        "status_per_communication": {},
+        "total_saved": 0
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    result = mock_client.upload_communications(communications)
+
+    assert result.total_saved == 0
+    assert len(result.status_per_communication) == 0
+
+
+def test_upload_communications_with_optional_fields(mock_client):
+    """Тест загрузки с опциональными полями"""
+    communications = [
+        CommunicationRequest(
+            source_entity_id="optional_test",
+            most_communication_id="most-optional",
+            start_dt="2024-01-01T17:00:00Z",
+            end_dt="2024-01-01T17:05:00Z",
+            manager="Тест Опциональный",
+            talk_duration=250,
+            client_phone="+79991234567",
+            wait_duration=30,
+            status="completed",
+            communication_result="answered",
+            extra_fields={"custom_field": "value"},
+            tech_fields={"tech_field": 123}
+        )
+    ]
+
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json.return_value = {
+        "status_per_communication": {
+            "optional_test": {"reason": "saved", "success": True}
+        },
+        "total_saved": 1,
+        "success": True
+    }
+
+    mock_client.session.post = Mock(return_value=mock_response)
+
+    result = mock_client.upload_communications(communications)
+
+    assert result.total_saved == 1
+    # Проверяем, что опциональные поля были переданы
+    call_args = mock_client.session.post.call_args
+    request_data = call_args[1]["json"]
+    comm_data = request_data["communications"][0]
+    assert comm_data["client_phone"] == "+79991234567"
+    assert comm_data["wait_duration"] == 30
+    assert comm_data["extra_fields"] == {"custom_field": "value"}
+


### PR DESCRIPTION
- Add upload_communications method to MostClient
- Add CommunicationRequest, CommunicationBatchRequest, CommunicationBatchResponse types
- Add etl_base_url parameter to MostClient constructor
- Add unit and e2e tests
- Add example notebook
- Fix __repr__ and clone() methods